### PR TITLE
Change ClientError to extend from Exception instead of BaseException.

### DIFF
--- a/voysis/client/client.py
+++ b/voysis/client/client.py
@@ -8,7 +8,7 @@ from dateutil.tz import tzutc
 from voysis.client.user_agent import UserAgent
 
 
-class ClientError(BaseException):
+class ClientError(Exception):
     def __init__(self, *args, **kwargs):
         super(ClientError, self).__init__(*args, **kwargs)
         if args and len(args) > 0:


### PR DESCRIPTION
From the python documentation:  The built-in exception classes can be subclassed to define new exceptions; programmers are encouraged to derive new exceptions from the Exception class or one of its subclasses, and not from BaseException.

Having ClientError extend from BaseException causes problems when using this library in other tools (such as the behave framework) that consider exceptions that extend directly from BaseException to be terminal and exit the program.