### PR TITLE
Fix keyboard-interaction to stop recording.

### DIFF
--- a/voysis/device/device.py
+++ b/voysis/device/device.py
@@ -19,5 +19,9 @@ class Device(object):
         pass
 
     @abc.abstractmethod
+    def is_recording(self):
+        pass
+
+    @abc.abstractmethod
     def generate_frames(self):
         pass

--- a/voysis/device/file_device.py
+++ b/voysis/device/file_device.py
@@ -25,6 +25,9 @@ class FileDevice(Device):
     def stop_recording(self):
         self._queue.queue.clear()
 
+    def is_recording(self):
+        return not(self._queue.queue.empty())
+
     def generate_frames(self):
         while not self._queue.empty():
             data = self._queue.get_nowait()

--- a/voysis/device/mic_device.py
+++ b/voysis/device/mic_device.py
@@ -39,12 +39,16 @@ class MicDevice(Device):
             stream_callback = self._callback,
             input_device_index = self.device_index
         )
+        self.quit_event.clear()
         self.queue.queue.clear()
         self.stream.start_stream()
 
     def stop_recording(self):
         self.stream.stop_stream()
         self.quit_event.set()
+
+    def is_recording(self):
+        return not(self.quit_event.is_set())
 
     def generate_frames(self):
         self.quit_event.clear()


### PR DESCRIPTION
Processing `KeyboardInterrupt` wasn't working after the various refactoring that had occurred. This fixes things to allow the user to press Enter a second time to manually stop recording.