### PR TITLE
Remove the hard-coded timeout for refreshing an app token.

### DIFF
--- a/voysis/client/client.py
+++ b/voysis/client/client.py
@@ -65,6 +65,7 @@ class Client(object):
         self.locale = 'en-US'
         self.check_hostname = True
         self.auth_token = None
+        self.timeout = None
         self.current_conversation_id = None
         self.current_context = None
         self.app_token_renewal_grace = timedelta(seconds=180)
@@ -164,7 +165,7 @@ class Client(object):
                 '/tokens', extra_headers=auth_headers, call_on_complete=self._update_app_token
             )
             if not self._app_token:
-                response_future.wait_until_complete(5)
+                response_future.wait_until_complete(self.timeout)
         return self._app_token
 
     def _create_audio_query_entity(self):

--- a/voysis/client/http_client.py
+++ b/voysis/client/http_client.py
@@ -24,7 +24,8 @@ class HTTPClient(client.Client):
             str(url),
             headers=headers,
             json=request_entity,
-            verify=self.check_hostname
+            verify=self.check_hostname,
+            timeout=self.timeout
         )
         return client.ResponseFuture(
             response_code=response.status_code,
@@ -47,6 +48,7 @@ class HTTPClient(client.Client):
                 headers=headers,
                 stream=True,
                 verify=self.check_hostname,
+                timeout=self.timeout,
                 data=frames_generator
             )
             if response.status_code == 200:

--- a/voysis/client/ws_client.py
+++ b/voysis/client/ws_client.py
@@ -6,9 +6,8 @@ from voysis.client import client as client
 
 class WSClient(client.Client):
 
-    def __init__(self, url, user_agent=None, timeout=15):
+    def __init__(self, url, user_agent=None):
         client.Client.__init__(self, url, user_agent)
-        self._timeout = timeout
         self._websocket_app = None
         self._web_socket_thread = None
         self._next_request_id = 1
@@ -175,7 +174,7 @@ class WSClient(client.Client):
             self._notification_handler = None
 
     def _wait_for_event(self, message):
-        if not self._event.wait(self._timeout):
+        if not self._event.wait(self.timeout):
             raise client.ClientError("Timed out waiting on " + message)
         if self._error:
             raise self._error

--- a/voysis/cmd/vtc.py
+++ b/voysis/cmd/vtc.py
@@ -159,6 +159,11 @@ def write_context(url, context, saved_context_file):
     '--check-hostname/--no-check-hostname', is_flag=True, default=True,
     help='For TLS, enable or disable hostname verification. Enabled by default.'
 )
+@click.option(
+    '--timeout', envvar='VTC_TIMEOUT', default=20,
+    help='The time (in seconds) that the client will wait for a response from the service.'
+         ' Can be provided in the environment using VTC_TIMEOUT'
+)
 @click.version_option(version=__version__)
 @click.pass_context
 def vtc(context, **kwargs):
@@ -169,6 +174,7 @@ def vtc(context, **kwargs):
         voysis_client.audio_profile_id = kwargs['audio_profile_id']
     voysis_client.auth_token = kwargs['auth_token']
     voysis_client.check_hostname = kwargs['check_hostname']
+    voysis_client.timeout = kwargs['timeout']
     context.obj = {
         'url': url,
         'voysis_client': voysis_client,


### PR DESCRIPTION
Add a timeout that can be specified to the command-line client for HTTP and WebSocket requests.